### PR TITLE
#2670 Replace explicit usage of eq with should be from kotest assertion core

### DIFF
--- a/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/Utils.kt
+++ b/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/Utils.kt
@@ -1,5 +1,3 @@
-@file:Suppress("UNCHECKED_CAST")
-
 package io.kotest.assertions.arrow
 
 import io.kotest.matchers.shouldBe as coreShouldBe

--- a/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/Utils.kt
+++ b/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/Utils.kt
@@ -2,30 +2,16 @@
 
 package io.kotest.assertions.arrow
 
-import io.kotest.assertions.assertionCounter
-import io.kotest.assertions.collectOrThrow
-import io.kotest.assertions.eq.eq
-import io.kotest.assertions.errorCollector
-import io.kotest.matchers.Matcher
-import io.kotest.matchers.equalityMatcher
-import io.kotest.matchers.invokeMatcher
+import io.kotest.matchers.shouldBe as coreShouldBe
+import io.kotest.matchers.shouldNotBe as coreShouldNotBe
 
-internal infix fun <A> A.shouldBe(a: A): A =
-  when (a) {
-    is Matcher<*> -> invokeMatcher(this, a as Matcher<A>)
-    else -> {
-      val actual = this
-      assertionCounter.inc()
-      eq(actual, a)?.let(errorCollector::collectOrThrow)
-      actual
-    }
-  }
+internal infix fun <A> A.shouldBe(a: A): A {
+  this coreShouldBe a
+  return this
+}
 
-internal infix fun <A> A.shouldNotBe(a: A?): A =
-  when (a) {
-    is Matcher<*> -> invokeMatcher(this, (a as Matcher<A>).invert())
-    else -> {
-      invokeMatcher(this, equalityMatcher(a).invert())
-      this
-    }
-  }
+
+internal infix fun <A> A.shouldNotBe(a: A?): A {
+  this coreShouldNotBe a
+  return this
+}


### PR DESCRIPTION
Using `eq` directly from kotest assertion core/shared is causing backward compatibility issue arrow assertion.  Replace that with shouldBe from core fixes that issue.