### PR TITLE
Publish to all targets

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,36 +16,6 @@ env:
   ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
 
 jobs:
-  linux:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Setup JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: '8'
-
-      - name: Run tests
-        run: ./gradlew check --scan
-
-      - name: publish snapshots
-        run: ./gradlew publish
-
-      - name: Bundle the build report
-        if: failure()
-        run: find . -type d -name 'reports' | zip -@ -r build-reports.zip
-
-      - name: Upload the build report
-        if: failure()
-        uses: actions/upload-artifact@master
-        with:
-          name: error-report
-          path: build-reports.zips
-
   macos:
     runs-on: macos-11
     steps:
@@ -60,43 +30,11 @@ jobs:
           java-version: '8'
 
       - name: Run macos tests
-        run: ./gradlew macosX64Test macosArm64Test iosX64Test iosSimulatorArm64Test tvosX64Test tvosSimulatorArm64Test watchosX64Test watchosX86Test watchosSimulatorArm64Test --scan
-
+        run: ./gradlew check --scan
+        
       - name: publish macos snapshots
         run: |
-            ./gradlew publishMacosX64PublicationToDeployRepository publishMacosArm64PublicationToDeployRepository publishIosArm32PublicationToDeployRepository publishIosArm64PublicationToDeployRepository \
-            publishTvosArm64PublicationToDeployRepository publishTvosSimulatorArm64PublicationToDeployRepository publishWatchosArm32PublicationToDeployRepository publishIosSimulatorArm64PublicationToDeployRepository \
-            publishWatchosArm64PublicationToDeployRepository publishWatchosX64PublicationToDeployRepository publishWatchosX86PublicationToDeployRepository publishWatchosSimulatorArm64PublicationToDeployRepository
-
-      - name: Bundle the build report
-        if: failure()
-        run: find . -type d -name 'reports' | zip -@ -r build-reports.zip
-
-      - name: Upload the build report
-        if: failure()
-        uses: actions/upload-artifact@master
-        with:
-          name: error-report
-          path: build-reports.zip
-
-  windows:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Setup JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: '8'
-
-      - name: Run tests
-        run: ./gradlew mingwX64Test --scan
-
-      - name: publish mingw64 snapshot
-        run: ./gradlew publishMingwX64PublicationToDeployRepository
+            ./gradlew publish
 
       - name: Bundle the build report
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: deploy to sonatype
         run: |
-          ./gradlew publishToSonatype
+          ./gradlew publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,26 +21,8 @@ env:
   ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
 
 jobs:
-  linux:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.branch }}
-
-      - name: Setup JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: '8'
-
-      - name: deploy to sonatype
-        run: ./gradlew publish
-
   macos:
-    runs-on: macos-11
+    runs-on: macos-latest
 
     steps:
       - name: Checkout the repo
@@ -56,24 +38,4 @@ jobs:
 
       - name: deploy to sonatype
         run: |
-          ./gradlew publishMacosX64PublicationToDeployRepository publishMacosArm64PublicationToDeployRepository publishIosArm32PublicationToDeployRepository publishIosArm64PublicationToDeployRepository \
-          publishTvosArm64PublicationToDeployRepository publishTvosSimulatorArm64PublicationToDeployRepository publishWatchosArm32PublicationToDeployRepository publishIosSimulatorArm64PublicationToDeployRepository \
-          publishWatchosArm64PublicationToDeployRepository publishWatchosX64PublicationToDeployRepository publishWatchosX86PublicationToDeployRepository publishWatchosSimulatorArm64PublicationToDeployRepository
-
-  windows:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.branch }}
-
-      - name: Setup JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: '8'
-
-      - name: deploy to sonatype
-        run: ./gradlew publishMingwX64PublicationToDeployRepository
+          ./gradlew publishToSonatype

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   macos:
-    runs-on: macos-12.5
+    runs-on: macos-11
 
     steps:
       - name: Checkout the repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   macos:
-    runs-on: macos-latest
+    runs-on: macos-12.5
 
     steps:
       - name: Checkout the repo

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 
 plugins {
   java
-  kotlin("multiplatform").version("1.6.0") apply false
+  kotlin("multiplatform").version("1.6.10") apply false
   `java-library`
   id("maven-publish")
   signing

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Affected version: 
`1.2.1`, `1.2.0`

There are missing targets unpublished.

In an mpp project I've encountered: 
```
:core:iosX64Test: Could not find io.kotest.extensions:kotest-assertions-arrow-iosx64:1.2.1.
Searched in the following locations:
  - https://repo.maven.apache.org/maven2/io/kotest/extensions/kotest-assertions-arrow-iosx64/1.2.1/kotest-assertions-arrow-iosx64-1.2.1.pom
```

Also updates kotlin to `1.6.10`