### PR TITLE
add kotest Matcher and Arb for Ior type

### DIFF
--- a/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Ior.kt
+++ b/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Ior.kt
@@ -18,7 +18,7 @@ import io.kotest.matchers.shouldNot
  * smart casts to [Ior.Right] and fails with [failureMessage] otherwise.
  */
 @OptIn(ExperimentalContracts::class)
-public fun <A, B> Ior<A, B>.shouldBeRight(failureMessage: (Ior<A,B>) -> String = { "Expected Ior.Right, but found ${it.javaClass.simpleName}" }): B {
+public fun <A, B> Ior<A, B>.shouldBeRight(failureMessage: (Ior<A,B>) -> String = { "Expected Ior.Right, but found ${it::class.simpleName}" }): B {
   contract {
     returns() implies (this@shouldBeRight is Right<B>)
   }
@@ -38,7 +38,7 @@ public infix fun <A, B> Ior<A, B>.shouldNotBeRight(b: B): B =
  * smart casts to [Ior.Left] and fails with [failureMessage] otherwise.
  */
 @OptIn(ExperimentalContracts::class)
-public fun <A, B> Ior<A, B>.shouldBeLeft(failureMessage: (Ior<A,B>) -> String = { "Expected Ior.Left, but found ${it.javaClass.simpleName}" }): A {
+public fun <A, B> Ior<A, B>.shouldBeLeft(failureMessage: (Ior<A,B>) -> String = { "Expected Ior.Left, but found ${it::class.simpleName}" }): A {
   contract {
     returns() implies (this@shouldBeLeft is Left<A>)
   }
@@ -58,7 +58,7 @@ public fun <A,B> beBoth(): Matcher<Ior<A,B>> = Matcher {
  ior ->
   MatcherResult(
     ior is Both,
-    { "Expected ior to be a Both, but was: ${ior.javaClass.simpleName}" },
+    { "Expected ior to be a Both, but was: ${ior::class.simpleName}" },
     { "Expected ior to not be a Both." }
   )
 }

--- a/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Ior.kt
+++ b/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Ior.kt
@@ -1,0 +1,78 @@
+package io.kotest.assertions.arrow.core
+
+import arrow.core.Ior
+import arrow.core.Ior.Left
+import arrow.core.Ior.Right
+import arrow.core.Ior.Both
+import arrow.core.identity
+import io.kotest.assertions.arrow.shouldBe
+import io.kotest.assertions.arrow.shouldNotBe
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
+
+/**
+ * smart casts to [Ior.Right] and fails with [failureMessage] otherwise.
+ */
+@OptIn(ExperimentalContracts::class)
+public fun <A, B> Ior<A, B>.shouldBeRight(failureMessage: (Ior<A,B>) -> String = { "Expected Ior.Right, but found ${it.javaClass.simpleName}" }): B {
+  contract {
+    returns() implies (this@shouldBeRight is Right<B>)
+  }
+  return when (this) {
+    is Right -> value
+    else -> throw AssertionError(failureMessage(this))
+  }
+}
+
+public infix fun <A, B> Ior<A, B>.shouldBeRight(b: B): B =
+  shouldBeRight().shouldBe(b)
+
+public infix fun <A, B> Ior<A, B>.shouldNotBeRight(b: B): B =
+  shouldBeRight().shouldNotBe(b)
+
+/**
+ * smart casts to [Ior.Left] and fails with [failureMessage] otherwise.
+ */
+@OptIn(ExperimentalContracts::class)
+public fun <A, B> Ior<A, B>.shouldBeLeft(failureMessage: (Ior<A,B>) -> String = { "Expected Ior.Left, but found ${it.javaClass.simpleName}" }): A {
+  contract {
+    returns() implies (this@shouldBeLeft is Left<A>)
+  }
+  return when (this) {
+    is Left -> value
+    else -> throw AssertionError(failureMessage(this))
+  }
+}
+
+public infix fun <A, B> Ior<A, B>.shouldBeLeft(a: A): A =
+  shouldBeLeft().shouldBe(a)
+
+public infix fun <A, B> Ior<A, B>.shouldNotBeLeft(a: A): A =
+  shouldBeLeft().shouldNotBe(a)
+
+public fun <A,B> beBoth(): Matcher<Ior<A,B>> = Matcher {
+ ior ->
+  MatcherResult(
+    ior is Both,
+    { "Expected ior to be a Both, but was: ${ior.javaClass.simpleName}" },
+    { "Expected ior to not be a Both." }
+  )
+}
+
+/**
+ * smart casts to [Ior.Both]
+ */
+@OptIn(ExperimentalContracts::class)
+public fun <A, B> Ior<A, B>.shouldBeBoth(): Ior.Both<A,B> {
+  contract {
+    returns() implies (this@shouldBeBoth is Ior.Both<A,B>)
+  }
+
+  this should beBoth()
+
+  return this as Ior.Both<A,B>
+}

--- a/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/IorMatchers.kt
+++ b/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/IorMatchers.kt
@@ -1,0 +1,52 @@
+package io.kotest.assertions.arrow.core
+
+import arrow.core.Ior
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import io.kotest.matchers.shouldBe
+
+class IorMatchers : StringSpec({
+  "shouldBeRight"{
+    checkAll(Arb.int()) { i ->
+      Ior.Right(i) shouldBeRight i
+    }
+  }
+
+  "shouldNotBeRight" {
+    checkAll(
+      Arb.bind(Arb.int(), Arb.int(), ::Pair)
+        .filter { (a, b) -> a != b }
+    ) { (a, b) ->
+      Ior.Right(a) shouldNotBeRight b
+    }
+  }
+
+  "shouldBeLeft"{
+    checkAll(Arb.int()) { i ->
+      Ior.Left(i) shouldBeLeft i
+    }
+  }
+
+  "shouldNotBeLeft" {
+    checkAll(
+      Arb.bind(Arb.int(), Arb.int(), ::Pair)
+        .filter { (a, b) -> a != b }
+    ) { (a, b) ->
+      Ior.Left(a) shouldNotBeLeft b
+    }
+  }
+
+  "shouldBeBoth" {
+    checkAll(Arb.int(), Arb.string()) { i,j ->
+      val ior = Ior.Both(i,j)
+      ior.shouldBeBoth()
+      ior.leftValue shouldBe i
+      ior.rightValue shouldBe j
+    }
+  }
+})

--- a/kotest-property-arrow/src/commonMain/kotlin/io/kotest/property/arrow/core/Ior.kt
+++ b/kotest-property-arrow/src/commonMain/kotlin/io/kotest/property/arrow/core/Ior.kt
@@ -1,0 +1,16 @@
+package io.kotest.property.arrow.core
+
+import arrow.core.Ior
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.choice
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.bind
+
+
+public fun <A, B> Arb.Companion.ior(left: Arb<A>, right: Arb<B>): Arb<Ior<A, B>> =
+  Arb.choice(left.map { Ior.Left(it) },
+             Arb.bind(left, right) { a, b -> Ior.Both(a, b) },
+             right.map { Ior.Right(it) })
+
+public fun <A, B> Arb<A>.alignWith(arbB: Arb<B>): Arb<Ior<A, B>> =
+  Arb.ior(this, arbB)

--- a/kotest-property-arrow/src/commonTest/kotlin/io/kotest/property/arrow/core/IorTests.kt
+++ b/kotest-property-arrow/src/commonTest/kotlin/io/kotest/property/arrow/core/IorTests.kt
@@ -1,0 +1,29 @@
+package io.kotest.property.arrow.core
+
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arrow.laws.shouldBe
+import io.kotest.property.checkAll
+import io.kotest.property.arbitrary.next
+import io.kotest.inspectors.forAtLeastOne
+
+class IorTests : StringSpec({
+  "Arb.ior should generate Left, Right & Both" {
+    assertSoftly(Arb.list(Arb.ior(Arb.string(), Arb.int())).next()) {
+      forAtLeastOne {
+        it.isRight.shouldBeTrue()
+      }
+      forAtLeastOne {
+        it.isBoth.shouldBeTrue()
+      }
+      forAtLeastOne {
+        it.isLeft.shouldBeTrue()
+      }
+    }
+  }
+})


### PR DESCRIPTION
this adds a kotest `Matcher` and `Arb` for the Arrow `Ior` type