### PR TITLE
feat: make raise matchers inline

### DIFF
--- a/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Raise.kt
+++ b/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Raise.kt
@@ -17,10 +17,10 @@ import io.kotest.assertions.print.print
  * }
  * ```
  */
-public suspend inline fun <reified T> shouldRaise(noinline block: suspend Raise<Any?>.() -> Any?): T {
+public inline fun <reified T> shouldRaise(block: Raise<Any?>.() -> Any?): T {
   val expectedRaiseClass = T::class
   return recover({
-    block()
+    block(this)
     throw failure("Expected to raise ${expectedRaiseClass.simpleName} but nothing was raised.")
   }) { raised ->
     when (raised) {
@@ -40,10 +40,8 @@ public suspend inline fun <reified T> shouldRaise(noinline block: suspend Raise<
  * }
  * ```
  */
-public suspend fun <T> shouldNotRaise(block: suspend Raise<Any?>.() -> T): T {
-  return recover({
-    block()
-  }) { raised ->
+public inline fun <T> shouldNotRaise(block: Raise<Any?>.() -> T): T {
+  return recover(block) { raised ->
     throw failure("No raise expected, but ${raised.print().value} was raised.")
   }
 }

--- a/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/RaiseMatchers.kt
+++ b/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/RaiseMatchers.kt
@@ -1,5 +1,6 @@
 package io.kotest.assertions.arrow.core
 
+import arrow.core.raise.Raise
 import io.kotest.assertions.arrow.shouldBe
 import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.core.spec.style.StringSpec
@@ -75,15 +76,25 @@ class RaiseMatchers : StringSpec({
 
   "shouldNotRaise: allows suspend call in block" {
     val res = shouldNotRaise {
-      suspend { 42 }.invoke()
+      suspend { 42 }()
     }
     res shouldBe 42
   }
 
   "shouldRaise: allows suspend call in block" {
     val res = shouldRaise<Int> {
-      raise(suspend { 42 }.invoke())
+      raise(suspend { 42 }())
     }
     res shouldBe 42
+  }
+
+  "shouldNotRaise: callable from non-suspend" {
+    fun test() = shouldNotRaise { "success" }
+    test() shouldBe "success"
+  }
+
+  "shouldRaise: callable from non-suspend" {
+    fun test() = shouldRaise<String> { raise("failed") }
+    test() shouldBe "failed"
   }
 })

--- a/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/RaiseMatchers.kt
+++ b/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/RaiseMatchers.kt
@@ -72,4 +72,18 @@ class RaiseMatchers : StringSpec({
       }
     }
   }
+
+  "shouldNotRaise: allows suspend call in block" {
+    val res = shouldNotRaise {
+      suspend { 42 }.invoke()
+    }
+    res shouldBe 42
+  }
+
+  "shouldRaise: allows suspend call in block" {
+    val res = shouldRaise<Int> {
+      raise(suspend { 42 }.invoke())
+    }
+    res shouldBe 42
+  }
 })


### PR DESCRIPTION
avoids propagation of suspend when raise/recover no longer requires it